### PR TITLE
fix: correct prefix for frontend Docker updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,7 +22,7 @@ updates:
     schedule:
       interval: "weekly"
     commit-message:
-      prefix: "chore(backend-docker)"
+      prefix: "chore(frontend-docker)"
 
   - package-ecosystem: "docker"
     directory: "/backend"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency automation configuration to correctly label frontend Docker updates with the appropriate commit message prefix, improving commit history clarity and alignment with repository conventions. This streamlines maintenance and supports consistent release processes. No functional changes, performance impact, or user-facing differences are introduced.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->